### PR TITLE
Memoize Supabase client in useUser hook

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -1,11 +1,11 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { createClient } from "@/lib/supabase/client"
 import { User } from "@supabase/supabase-js"
 
 export function useUser() {
-  const supabase = createClient()
+  const supabase = useMemo(() => createClient(), [])
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
 


### PR DESCRIPTION
## Summary
- memoize Supabase client in `useUser` hook to avoid creating new instances

## Testing
- `npm run lint` *(fails: Parsing error: Unexpected keyword or identifier.)*
- `npm run typecheck` *(fails: Unexpected keyword or identifier.)*
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689d527aa7608331af686b7db03ddd5c