### PR TITLE
Add error handling to useUser hook

### DIFF
--- a/src/hooks/use-user.ts
+++ b/src/hooks/use-user.ts
@@ -8,31 +8,48 @@ export function useUser() {
   const supabase = createClient()
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
     const getUser = async () => {
-      const { data: { user } } = await supabase.auth.getUser()
-      setUser(user)
-      setLoading(false)
+      try {
+        const { data: { user }, error: getUserError } = await supabase.auth.getUser()
+        if (getUserError) throw getUserError
+        setUser(user)
+      } catch (err) {
+        console.error("Erro ao buscar usuário", err)
+        setError((err as Error).message)
+      } finally {
+        setLoading(false)
+      }
     }
 
     getUser()
 
-    const { data: authListener } = supabase.auth.onAuthStateChange(
-      async (event, session) => {
-        if (event === "SIGNED_IN") {
-          setUser(session?.user || null)
-        } else if (event === "SIGNED_OUT") {
-          setUser(null)
+    let authListener: { subscription: { unsubscribe: () => void } } | null = null
+    try {
+      const { data: listener, error: authListenerError } = supabase.auth.onAuthStateChange(
+        async (event, session) => {
+          if (event === "SIGNED_IN") {
+            setUser(session?.user || null)
+          } else if (event === "SIGNED_OUT") {
+            setUser(null)
+          }
+          setLoading(false)
         }
-        setLoading(false)
-      }
-    )
+      )
+      if (authListenerError) throw authListenerError
+      authListener = listener
+    } catch (err) {
+      console.error("Erro ao observar mudanças de autenticação", err)
+      setError((err as Error).message)
+      setLoading(false)
+    }
 
     return () => {
-      authListener.subscription.unsubscribe()
+      authListener?.subscription.unsubscribe()
     }
   }, [supabase])
 
-  return { user, loading }
+  return { user, loading, error }
 }


### PR DESCRIPTION
## Summary
- handle Supabase getUser errors with try/catch
- handle onAuthStateChange errors and expose error state

## Testing
- `npm run lint` (fails: Parsing error in src/lib/supabase.types.ts)
- `npm run typecheck` (fails: unexpected keywords in src/lib/supabase.types.ts)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689d5280edd883319cf692e33522fa34