### PR TITLE
fix: subscribe toast hook once

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- ensure toast hook subscription effect runs only on mount

## Testing
- ⚠️ `pnpm lint` *(error fetching pnpm)*
- ❌ `npm run lint`
- ❌ `npm run typecheck`
- ❌ `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d528ffddc833185f61e85aa3151b2