### PR TITLE
Reduce toast removal delay to 5 seconds

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- set TOAST_REMOVE_DELAY to 5000ms for quicker toast cleanup

## Testing
- `npm run lint` (fails: Parsing error in src/lib/supabase.types.ts)
- `npm run typecheck` (fails: Unexpected keyword in src/lib/supabase.types.ts)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_689d52a14f408331a0ad8be2b877690d