### PR TITLE
refactor: use new supabase client

### DIFF
--- a/src/app/meus-pedidos/[id]/page.tsx
+++ b/src/app/meus-pedidos/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createClient } from '@/lib/supabase/client'
 import { Database } from '@/lib/supabase.types'
 import Link from 'next/link'
 
@@ -18,7 +18,7 @@ type OrderDetails = Order & { order_items: OrderItem[] }
 export default function OrderConfirmationPage() {
   const params = useParams()
   const { id } = params
-  const supabase = createClientComponentClient<Database>()
+  const supabase = createClient()
 
   const [order, setOrder] = useState<OrderDetails | null>(null)
   const [loading, setLoading] = useState(true)

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,8 +1,9 @@
 import { createBrowserClient } from '@supabase/ssr'
+import type { Database } from '@/lib/supabase.types'
 
-export function createClient() {
-  return createBrowserClient(
+export const createClient = () =>
+  createBrowserClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   )
-}
+


### PR DESCRIPTION
## Summary
- export typed Supabase browser client factory
- use new client on order page and drop auth helpers

## Testing
- `npm install`
- `npm test` *(fails: no test specified)*
- `npm run lint`
- `npm run typecheck` *(fails: Module '@supabase/ssr' has no exported member 'createMiddlewareClient', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e57944e8c8331b7524636e71da027