### PR TITLE
refactor search form into client component

### DIFF
--- a/src/app/busca/page.tsx
+++ b/src/app/busca/page.tsx
@@ -1,45 +1,20 @@
 import { Suspense } from 'react';
 import { ProductList } from '@/components/product-list';
 import { ProductFilters } from '@/components/product-filters';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { useRouter } from 'next/navigation';
+import { SearchForm } from '@/components/search-form';
 
 interface SearchPageProps {
   searchParams: { [key: string]: string | string[] | undefined };
 }
 
-export default function SearchPage({
-  searchParams,
-}: SearchPageProps) {
-  const router = useRouter();
-  const searchTerm = searchParams.get('q') || '';
-
-  const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const formData = new FormData(event.currentTarget);
-    const query = formData.get('query');
-    if (query) {
-      router.push(`/busca?q=${query}`);
-    } else {
-      router.push('/busca');
-    }
-  };
+export default function SearchPage({ searchParams }: SearchPageProps) {
+  const searchTerm = typeof searchParams.q === 'string' ? searchParams.q : '';
 
   return (
     <div className="container mx-auto py-8">
       <h1 className="text-3xl font-bold mb-6">Busca de Produtos</h1>
 
-      <form onSubmit={handleSearch} className="flex gap-2 mb-6">
-        <Input
-          type="text"
-          name="query"
-          placeholder="Buscar produtos..."
-          defaultValue={searchTerm}
-          className="flex-1"
-        />
-        <Button type="submit">Buscar</Button>
-      </form>
+      <SearchForm initialQuery={searchTerm} />
 
       <ProductFilters />
 

--- a/src/components/search-form.tsx
+++ b/src/components/search-form.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+
+interface SearchFormProps {
+  initialQuery?: string;
+}
+
+export function SearchForm({ initialQuery = '' }: SearchFormProps) {
+  const router = useRouter();
+
+  const handleSearch = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const query = formData.get('query');
+    if (query) {
+      router.push(`/busca?q=${query}`);
+    } else {
+      router.push('/busca');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSearch} className="flex gap-2 mb-6">
+      <Input
+        type="text"
+        name="query"
+        placeholder="Buscar produtos..."
+        defaultValue={initialQuery}
+        className="flex-1"
+      />
+      <Button type="submit">Buscar</Button>
+    </form>
+  );
+}
+


### PR DESCRIPTION
## Summary
- move search form and router logic to new client component
- keep search page server-side while still rendering product filters

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint`
- `npm run typecheck` *(fails: Property 'amount' is missing, and more)*

------
https://chatgpt.com/codex/tasks/task_e_689e579614b48331935cdaf8f157ce80