### PR TITLE
refactor: access search params object directly

### DIFF
--- a/src/app/busca/page.tsx
+++ b/src/app/busca/page.tsx
@@ -13,7 +13,8 @@ export default function SearchPage({
   searchParams,
 }: SearchPageProps) {
   const router = useRouter();
-  const searchTerm = searchParams.get('q') || '';
+  const searchTerm =
+    typeof searchParams.q === 'string' ? searchParams.q : '';
 
   const handleSearch = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- read query parameters directly from `searchParams` in search page

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint`
- `npm run typecheck` (fails: Module '@supabase/ssr' has no exported member)


------
https://chatgpt.com/codex/tasks/task_e_689e5797f48c8331b8d30fd6b8b10748